### PR TITLE
update to flyd 0.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,13 @@ var flyd = require('flyd');
 
 function dropRepeatsWith(eq, s) {
   var prev;
-  return flyd.stream([s], function(self) {
-    if (!eq(s.val, prev)) {
-      self(s.val);
-      prev = s.val;
+  return flyd.combine(function(s) {
+    var current = s();
+    if (!eq(current, prev)) {
+      prev = current;
+      return current;
     }
-  });
+  }, [s]);
 }
 
 exports.dropRepeats = function(s) {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
   "repository": "raine/flyd-droprepeats",
   "author": "Raine Virta <raine.virta@gmail.com>",
   "license": "MIT",
+  "peerDependencies": {
+    "flyd": "~0.2.0"
+  },
   "dependencies": {
-    "flyd": "^0.1.13"
+    "flyd": "~0.2.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
Added flyd in peer dependencies so people will get an error if trying to use with an incompatible version of Flyd. I also changed the flyd dependency to be `0.2.x` only as it doesn't follow semver.
